### PR TITLE
Implement optional use of BSpline

### DIFF
--- a/airPlaneDesingProfilUI.py
+++ b/airPlaneDesingProfilUI.py
@@ -22,7 +22,7 @@ import os,FreeCAD,FreeCADGui
 
 from PySide import QtCore, QtGui
 from PySide.QtGui import QLineEdit, QRadioButton
-from  airPlaneAirFoilNaca import generateNacaChoords
+from  airPlaneAirFoilNaca import generateNacaCoords
 import FreeCAD, FreeCADGui, Draft, Part
 import glob, os.path
 
@@ -93,14 +93,14 @@ class SelectObjectUI():
         return
         
     def updateGraphicsViewRib(self):
-        choords=[]
+        coords=[]
         number=self.form.NACANumber.text()
         if len(number)==4:
-             #choords=naca4(number, n, finite_TE, half_cosine_spacing)
-             choords=generateNacaChoords(number,self.form.nacaNbrPoint.value(),False,0,self.form.choord.value(),0,0,0,0,0,0)
+             #coords=naca4(number, n, finite_TE, half_cosine_spacing)
+             coords=generateNacaCoords(number,self.form.nacaNbrPoint.value(),False,0,self.form.choord.value(),0,0,0,0,0,0)
         elif len(number)==5:
-             #choords=naca5(number, n, finite_TE, half_cosine_spacing)
-             choords=generateNacaChoords(number,self.form.nacaNbrPoint.value(),False,0,self.form.choord.value(),0,0,0,0,0,0)
+             #coords=naca5(number, n, finite_TE, half_cosine_spacing)
+             coords=generateNacaCoords(number,self.form.nacaNbrPoint.value(),False,0,self.form.choord.value(),0,0,0,0,0,0)
         else :
              return    
         
@@ -115,7 +115,7 @@ class SelectObjectUI():
              points=[]
              first_v = None
              last_v = None
-             for v in choords:
+             for v in coords:
                  if first_v == None:
                      first_v = v
             # End of if first_v == None

--- a/selectRibProfil.ui
+++ b/selectRibProfil.ui
@@ -49,7 +49,7 @@
     </rect>
    </property>
    <property name="text">
-    <string>Select the profil/sélectionner un profil</string>
+    <string>Select a profile/sélectionner un profil</string>
    </property>
   </widget>
   <widget class="QLabel" name="label_2">


### PR DESCRIPTION
Hi! This pull request implements the usage of Part.BSplineCurve for the airfoils, making them smoother. This behavior is controlled trough the useBSpline boolean that defaults to True in the functions, a GUI method of stablishing this value has to be implemented (a checkbox for example, with it's corresponding property).

I have tested making ribs from: naca2412.dat, eppler205.dat, naca 4 and 5 digits. I also tested changing the choord length after creation, changing the dat file, changing naca digits, and switching from naca to dat file and vice-versa. Also tested generating the default panel. All seems to work.
![wing](https://user-images.githubusercontent.com/36372335/67648108-75596b00-f913-11e9-948f-bc303867102b.png)