### PR TITLE
Fix remaining choord typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ In the menu AiplaneDesign select create a RIB, the dialog below appears, clic on
 
 ![DAT folder](resources/RIBSGUI1.png)
 
-Select in the tree the dat file you want to use and define the choord of the rib and clic OK. That's all.
-You can change directly in the GUI of the object the Dat File, the Choord (in mm). 
+Select in the tree the dat file you want to use and define the chord of the rib and clic OK. That's all.
+You can change directly in the GUI of the object the Dat File, the chord (in mm). 
 
 1.3 Use the NACA Generator
-You can generate Naca profil 4 or 5 digits. In the menu AiplaneDesign select create a RIB, the dialog below appears, clic on the tab "NACA Generator". Simply fil the NACA Number, the number of points you want to generate and the choord in mm. A preview is automatically generate. 
+You can generate Naca profil 4 or 5 digits. In the menu AiplaneDesign select create a RIB, the dialog below appears, clic on the tab "NACA Generator". Simply fil the NACA Number, the number of points you want to generate and the chord in mm. A preview is automatically generate. 
 
 ![RibGUI](resources/RibGUI.png)
 

--- a/airPlaneRib.py
+++ b/airPlaneRib.py
@@ -161,14 +161,14 @@ class CommandWingRib:
             if editor.form.NACANumber.text()=="" :
                 b=editor.profilSelectedFilePath()#currentItem()
                 a=FreeCAD.ActiveDocument.addObject("Part::FeaturePython","wrib")
-                WingRib(a,b,False,0,editor.form.choord.value(),0,0,0,0,0,0,(editor.form.kingOfLines.isChecked() == True))
+                WingRib(a,b,False,0,editor.form.chord.value(),0,0,0,0,0,0,(editor.form.kingOfLines.isChecked() == True))
                 ViewProviderWingRib(a.ViewObject)
             else :
                 print("Naca : ") 
                 print( editor.form.NACANumber)
                 b=editor.form.NACANumber
                 a=FreeCAD.ActiveDocument.addObject("Part::FeaturePython","wrib")
-                WingRib(a,b.text(),True,int(editor.form.nacaNbrPoint.value()),editor.form.choord.value(),0,0,0,0,0,0,(editor.form.kingOfLines.isChecked() == True))
+                WingRib(a,b.text(),True,int(editor.form.nacaNbrPoint.value()),editor.form.chord.value(),0,0,0,0,0,0,(editor.form.kingOfLines.isChecked() == True))
                 ViewProviderWingRib(a.ViewObject)
             FreeCAD.ActiveDocument.recompute()
         else :

--- a/airPlaneWingUI.py
+++ b/airPlaneWingUI.py
@@ -45,7 +45,7 @@ class WingEditorPanel():
         
         ##########################
         # Numéro du panneau, profil, fichier profil, , corde emplature, corde saumon, longueur paneau, X emplature, X saumon, Y emplature, Y saumon, Z emplature, Z saumon, X Rotation, Y Rotation, Z Rotation
-        # Panel Number, Profil, Profil file (DAT), Root rib choord, End rib choords, panel length, X position of Root rib ,X position of end rib , Y position of Root rib ,Y position of end rib, Z position of Root rib ,Z position of end rib, X angle of root rib,   Y angle of root rib,  Z angle of root rib,    
+        # Panel Number, Profil, Profil file (DAT), Root rib chord, End rib chords, panel length, X position of Root rib ,X position of end rib , Y position of Root rib ,Y position of end rib, Z position of Root rib ,Z position of end rib, X angle of root rib,   Y angle of root rib,  Z angle of root rib,    
      
         initPanelTable = [
              ["1","Eppler207",_wingRibProfilDir+u"/naca/naca2412.dat","250","222","122","0","0","0.0","-54.","0","0","22"],
@@ -107,7 +107,7 @@ class WingEditorPanel():
         #self._photo = self.form.planeView()
         #scene.addItem(self.form.planeView()) #self._photo)
         
-        #scene.setSceneRect(QtCore.QRectF(-10, -400, 400, 10+self.form.choord.value()))
+        #scene.setSceneRect(QtCore.QRectF(-10, -400, 400, 10+self.form.chord.value()))
         #item=QtGui.QGraphicsLineItem(-100,  0, 1000,  0)
         
 class CommandWizard():


### PR DESCRIPTION
Hi, when testing the workbench after updating today I found this bug:
```
Running the Python command 'airPlaneDesingWRib' failed:
Traceback (most recent call last):
  File "/home/adrian/.FreeCAD/Mod/AirPlaneDesign/airPlaneRib.py", line 171, in Activated
    WingRib(a,b.text(),True,int(editor.form.nacaNbrPoint.value()),editor.form.choord.value(),0,0,0,0,0,0,(editor.form.kingOfLines.isChecked() == True))

'PySide2.QtWidgets.QDialog' object has no attribute 'choord'
```

This pull request fixes it.