### PR TITLE
Fix bug preventing recompute on ribs generated from dat file + minor improvements

### DIFF
--- a/airPlaneAirFoil.py
+++ b/airPlaneAirFoil.py
@@ -20,16 +20,13 @@
 #*   USA                                                                   *
 #*                                                                         *
 #***************************************************************************
-# Modificaiotn by F. Nivoix to integrate 
-# in Airplane workbench 2019 - 
+# Modificaiotn by F. Nivoix to integrate
+# in Airplane workbench 2019 -
 # V0.1, V0.2 & V0.3
 #***************************************************************************
 
-import FreeCAD,FreeCADGui
-from PySide import QtCore
-from FreeCAD import Vector, Base
+import FreeCAD,FreeCADGui,Part
 FreeCADGui.addLanguagePath(":/translations")
-import re, Part
 
 # Qt translation handling
 def translate(context, text, disambig=None):
@@ -81,7 +78,7 @@ def readpointsonfile(filename):
            y = 0#posY
            z = float(curdat.group("yval"))
            # the normal processing
-           coords.append(Vector(x,y,z))
+           coords.append(FreeCAD.Vector(x,y,z))
         # End of if curdat != None
     # End of for lin in file
     afile.close
@@ -149,7 +146,7 @@ def process(doc,filename,scale,posX,posY,posZ,rotX,rotY,rotZ,thickness,useSpline
     face = Part.Face(wire)
 
     #Scale the foil
-    myScale = Base.Matrix()
+    myScale = FreeCAD.Base.Matrix()
     myScale.scale(scale,1,scale)
     face=face.transformGeometry(myScale)
 

--- a/airPlaneAirFoil.py
+++ b/airPlaneAirFoil.py
@@ -69,7 +69,6 @@ def readpointsonfile(filename):
     # read the airfoil name which is always at the first line
     #airfoilname = afile.readline().strip()
     coords=[]
-    geometry=[]
     #upside=True
     #last_x=None
     # Collect the data for the upper and the lower side separately if possible
@@ -83,7 +82,6 @@ def readpointsonfile(filename):
            z = float(curdat.group("yval"))
            # the normal processing
            coords.append(Vector(x,y,z))
-           geometry.append(Part.Point(FreeCAD.Vector(x,y,z)))
         # End of if curdat != None
     # End of for lin in file
     afile.close
@@ -96,20 +94,14 @@ def readpointsonfile(filename):
     # check for start coordinates in the middle of list
 
     if coords[0:-1].count(coords[0]) > 1:
-        geometry=[]
         flippoint = coords.index(coords[0],1)
         upper = coords[0:flippoint]
         lower = coords[flippoint+1:]
         lower.reverse()
-        #for i in lower:
-            #upper.append(i)
-            #geometry.append(Part.Point(FreeCAD.Vector(i)))
-        #coords = upper
-        
+
         coords = upper
         coords.extend(lower)
-        geometry=coords
-    return coords,geometry
+    return coords
 
 def process(doc,filename,scale,posX,posY,posZ,rotX,rotY,rotZ,thickness,useSpline = False,coords=[]):
     print("")
@@ -119,9 +111,9 @@ def process(doc,filename,scale,posX,posY,posZ,rotX,rotY,rotZ,thickness,useSpline
     print("rotX :",rotX,"rotY :",rotY,"rotZ :",rotZ)
     print("thickness :",thickness, ", useSpline:",useSpline)
     print("coords :", coords)
-    
+
     if len(coords) == 0 :
-        coords,geometry = readpointsonfile(filename)
+        coords = readpointsonfile(filename)
     else :
         print("list of points are empty")
 
@@ -172,4 +164,4 @@ def process(doc,filename,scale,posX,posY,posZ,rotX,rotY,rotZ,thickness,useSpline
     #face.Placement(App.Vector(0,1,0),App.Rotation(App.Vector(0,0,0),posY))
     #face.Placement(App.Vector(0,0,1),App.Rotation(App.Vector(0,0,0),posZ))
 
-    return face, geometry
+    return face, coords

--- a/airPlaneAirFoilNaca.py
+++ b/airPlaneAirFoilNaca.py
@@ -191,7 +191,7 @@ def naca4(number, n, finite_TE = False, half_cosine_spacing = False):
     X = xu[::-1] + xl[1:]
     Z = yu[::-1] + yl[1:]
     # AiplaneDesign modification - start
-    coords=[] 
+    coords=[]
     for i in range(len(X)) :
         coords.append(Vector(X[i],0,Z[i]))
     return coords
@@ -295,17 +295,7 @@ def generateNacaCoords(number, n, finite_TE, half_cosine_spacing,scale,posX,posY
 
 
 def generateNaca(number, n=240, finite_TE = False, half_cosine_spacing = True,scale=1,posX=0,posY=0,posZ=0,rotX=0,rotY=0,rotZ=0, useSpline = True,coords=[]):
-    coords=[]
-    a=[]
-    if len(coords) == 0 :
-        coords=generateNacaCoords(number, n, finite_TE , half_cosine_spacing ,scale,posX,posY,posZ,rotX,rotY,rotZ,coords)
-    else :
-        print("list of points are empty")
-    
-    
-    for i in coords:
-      a.append(Part.Point(FreeCAD.Vector(i)))
-    
+    coords=generateNacaCoords(number, n, finite_TE , half_cosine_spacing ,scale,posX,posY,posZ,rotX,rotY,rotZ,coords)
     if useSpline:
         spline = Part.BSplineCurve()
         spline.interpolate(coords)
@@ -347,5 +337,5 @@ def generateNaca(number, n=240, finite_TE = False, half_cosine_spacing = True,sc
     face.Placement=FreeCAD.Placement(FreeCAD.Vector(0,0,0),FreeCAD.Rotation(FreeCAD.Vector(1,0,0),rotX))
     face.Placement=FreeCAD.Placement(FreeCAD.Vector(0,0,0),FreeCAD.Rotation(FreeCAD.Vector(0,1,0),rotY))
     face.Placement=FreeCAD.Placement(FreeCAD.Vector(0,0,0),FreeCAD.Rotation(FreeCAD.Vector(0,0,1),rotZ))
-        
-    return face, a   
+
+    return face, coords

--- a/airPlaneAirFoilNaca.py
+++ b/airPlaneAirFoilNaca.py
@@ -24,16 +24,13 @@ __author__ = "F. Nivoix"
 __url__ = "https://fredsfactory.fr"
 
 
-
-import FreeCAD, Part
-from FreeCAD import Vector, Base
+import FreeCAD,Part
 
 from math import cos, sin
 from math import atan
 from math import pi
 from math import pow
 from math import sqrt
-
 
 #Start #### Copyright (C) 2011 by Dirk Gorissen <dgorissen@gmail.com>####
 """
@@ -193,7 +190,7 @@ def naca4(number, n, finite_TE = False, half_cosine_spacing = False):
     # AiplaneDesign modification - start
     coords=[]
     for i in range(len(X)) :
-        coords.append(Vector(X[i],0,Z[i]))
+        coords.append(FreeCAD.Vector(X[i],0,Z[i]))
     return coords
 
    # AiplaneDesign modification - end
@@ -272,7 +269,7 @@ def naca5(number, n, finite_TE = False, half_cosine_spacing = False):
     # AiplaneDesign modification - start
     coords=[]
     for i in range(len(X)) :
-        coords.append(Vector(X[i],0,Z[i]))
+        coords.append(FreeCAD.Vector(X[i],0,Z[i]))
     return coords
 
    # AiplaneDesign modification - end
@@ -327,7 +324,7 @@ def generateNaca(number, n=240, finite_TE = False, half_cosine_spacing = True,sc
     face = Part.Face(wire)
 
         #Scale the foil
-    myScale = Base.Matrix()
+    myScale = FreeCAD.Base.Matrix()
     myScale.scale(scale,1,scale)
     face=face.transformGeometry(myScale)
 #move(face, FreeCAD.Vector(posX, posY, posZ))

--- a/airPlaneAirFoilNaca.py
+++ b/airPlaneAirFoilNaca.py
@@ -294,7 +294,7 @@ def generateNacaCoords(number, n, finite_TE, half_cosine_spacing,scale,posX,posY
     return coords
 
 
-def generateNaca(number, n=240, finite_TE = False, half_cosine_spacing = False,scale=1,posX=0,posY=0,posZ=0,rotX=0,rotY=0,rotZ=0, useSpline = True,coords=[]):
+def generateNaca(number, n=240, finite_TE = False, half_cosine_spacing = True,scale=1,posX=0,posY=0,posZ=0,rotX=0,rotY=0,rotZ=0, useSpline = True,coords=[]):
     coords=[]
     a=[]
     if len(coords) == 0 :

--- a/airPlaneDesignUI.py
+++ b/airPlaneDesignUI.py
@@ -40,9 +40,9 @@ class EditorPanel():
         headers = ["","Profil Num.","Name","File"]
         model = QtGui.QStandardItemModel()
         model.setHorizontalHeaderLabels(headers)
-        
-        model.setRowCount(10);
-        model.setColumnCount(3);
+
+        model.setRowCount(10)
+        model.setColumnCount(3)
         #self.form.tableWidget.setHorizontalHeaderLabels(QtGui.QTableWidgetItem("colonne1"))
         #model.appendRow(tooldata)
         self.form.tableWidget.setRowCount(0)

--- a/airPlaneDesingProfilUI.py
+++ b/airPlaneDesingProfilUI.py
@@ -148,10 +148,10 @@ class SelectObjectUI():
         number=self.form.NACANumber.text()
         if len(number)==4:
              #coords=naca4(number, n, finite_TE, half_cosine_spacing)
-             coords=generateNacaCoords(number,self.form.nacaNbrPoint.value(),False,0,self.form.chord.value(),0,0,0,0,0,0,coords)
+             coords=generateNacaCoords(number,self.form.nacaNbrPoint.value(),False,True,self.form.chord.value(),0,0,0,0,0,0,coords)
         elif len(number)==5:
              #coords=naca5(number, n, finite_TE, half_cosine_spacing)
-             coords=generateNacaCoords(number,self.form.nacaNbrPoint.value(),False,0,self.form.chord.value(),0,0,0,0,0,0,coords)
+             coords=generateNacaCoords(number,self.form.nacaNbrPoint.value(),False,True,self.form.chord.value(),0,0,0,0,0,0,coords)
         else :
              return    
         
@@ -184,16 +184,16 @@ class SelectObjectUI():
             # End of if first_v is None
             # Line between v and last_v if they're not equal
                  if (last_v != None) and (last_v != v):
-                     points.append(QtCore.QPointF(last_v.x*scale,last_v.z*scale ))
-                     points.append(QtCore.QPointF(v.x*scale,v.z*scale ))
+                     points.append(QtCore.QPointF(last_v.x*scale,-last_v.z*scale ))
+                     points.append(QtCore.QPointF(v.x*scale,-v.z*scale ))
             # End of if (last_v != None) and (last_v != v)
             # The new last_v
                  last_v = v
         # End of for v in upper
         # close the wire if needed
              if last_v != first_v:
-                     points.append(QtCore.QPointF(last_v.x*scale,last_v.z*scale ))
-                     points.append(QtCore.QPointF(first_v.x*scale,first_v.z*scale ))
+                     points.append(QtCore.QPointF(last_v.x*scale,-last_v.z*scale ))
+                     points.append(QtCore.QPointF(first_v.x*scale,-first_v.z*scale ))
              item=QtGui.QGraphicsPolygonItem(QtGui.QPolygonF(points))
              item.setPen(QtGui.QPen(QtCore.Qt.blue))
              scene.addItem(item)

--- a/airPlaneRib.py
+++ b/airPlaneRib.py
@@ -96,9 +96,9 @@ class WingRib:
                                    0,
                                    fp.useSpline,fp.Geometry)
         else :
-             a,fp.Geometry=generateNaca(fp.NacaProfil, fp.NacaNbrPoint, False, False,fp.Chord,fp.Placement.Base.x,fp.Placement.Base.y,fp.Placement.Base.z,fp.xrot,fp.yrot,fp.zrot,fp.useSpline,fp.Geometry)
+             a,fp.Geometry=generateNaca(fp.NacaProfil, fp.NacaNbrPoint, False, True,fp.Chord,fp.Placement.Base.x,fp.Placement.Base.y,fp.Placement.Base.z,fp.xrot,fp.yrot,fp.zrot,fp.useSpline,fp.Geometry)
 
-        
+
         fp.Shape=a
         FreeCAD.Console.PrintMessage("Create Rib End\n")
 

--- a/airPlaneRib.py
+++ b/airPlaneRib.py
@@ -25,14 +25,6 @@ __url__ = "https://fredsfactory.fr"
 
 
 import FreeCAD,FreeCADGui
-#import re
-#import Draft
-#import Part
-#import PartDesign
-#import PartDesignGui
-#import Sketcher
-#import cProfile
-#import string
 
 from PySide import QtCore
 from airPlaneAirFoil import process,decodeName

--- a/airPlaneRib.py
+++ b/airPlaneRib.py
@@ -70,13 +70,13 @@ class WingRib:
         obj.Placement.Base.y=_y
         obj.Placement.Base.z=_z
         # List Geomtry to edit list of points
-        obj.addProperty("Part::PropertyGeometryList","Geometry","Rib","Geometry").Geometry=[]
+        obj.addProperty("App::PropertyVectorList","Coordinates","Rib","Vector list that defines the airfoil's geometry").Coordinates=[]
         #obj.setEditorMode("MyPropertyName", mode) #2 -- hidden
-    
+
     def onChanged(self, fp, prop):
         '''Do something when a property has changed'''
         #FreeCAD.Console.PrintMessage("Change property: " + str(prop) + "\n")
-    
+
     def execute(self, fp):
         #   Do something when doing a recomputation, this method is mandatory
         if fp.NacaProfil =="" :
@@ -89,17 +89,16 @@ class WingRib:
               #         rotX,rotY,rotZ,
               #         thickness,
               #         useSpline = False,coords=[]):
-             a,fp.Geometry=process(FreeCAD.ActiveDocument.Name,fp.RibProfil,
+             fp.Shape,fp.Coordinates=process(FreeCAD.ActiveDocument.Name,fp.RibProfil,
                                    fp.Chord,
                                    fp.Placement.Base.x,fp.Placement.Base.y,fp.Placement.Base.z,
                                    fp.xrot,fp.yrot,fp.zrot,
                                    0,
-                                   fp.useSpline,fp.Geometry)
+                                   fp.useSpline,fp.Coordinates)
         else :
-             a,fp.Geometry=generateNaca(fp.NacaProfil, fp.NacaNbrPoint, False, True,fp.Chord,fp.Placement.Base.x,fp.Placement.Base.y,fp.Placement.Base.z,fp.xrot,fp.yrot,fp.zrot,fp.useSpline,fp.Geometry)
+             fp.Shape,fp.Coordinates=generateNaca(fp.NacaProfil, fp.NacaNbrPoint, False, True,fp.Chord,fp.Placement.Base.x,fp.Placement.Base.y,fp.Placement.Base.z,fp.xrot,fp.yrot,fp.zrot,fp.useSpline,fp.Coordinates)
 
 
-        fp.Shape=a
         FreeCAD.Console.PrintMessage("Create Rib End\n")
 
 class ViewProviderWingRib:


### PR DESCRIPTION
Please review the code, on he first commit the half_cosine_spacing parameter is passed as True by default, producing a much smoother LE in NACA profiles with fewer points, the following is a comparison using 100 instead of the default 240 points:
![new vs old](https://user-images.githubusercontent.com/36372335/77712369-ea57cc00-6fa9-11ea-877e-5b4dd93d591b.png)
green:half_cosine_spacing=True  red: half_cosine_spacing=False

on second commit the Geometry property wich was of type Part::PropertyGeometryList was replaced with the new Coordinates property of type App::PropertyVectorList. This is compatible with the coords variable used throughout the code so this is the variable that is stored instead of the ambiguous geometry variable.

The last commit just removes unnecesary colons and imports and follows a recommendation I've read on the FreeCAD forums: don't import specific functions from FreeCAD as it can be confusing, using FreeCAD.Vector and such makes it clear that it is a function from FreeCAD itself, I can't find the post at the moment but it was a tip from a developer.