### PR TITLE
Correct classname

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
 
   <content>
     <workbench>
-      <classname>AirplaneDesign</classname>
+      <classname>AirPlaneDesignWorkbench</classname>
       <subdirectory>./</subdirectory>
       <icon>resources/icons/appicon.svg</icon>
       <freecadmin>0.18.0</freecadmin>


### PR DESCRIPTION
The original version of this file used the incorrect classname: this commit fixes it.