### PR TITLE
[AirPlaneDesign] Python 3.11.x and above Json Fix for FreeCAD 0.21.2 …

### DIFF
--- a/airPlaneNacelle.py
+++ b/airPlaneNacelle.py
@@ -167,6 +167,17 @@ class ViewProviderskNacelle:
             Since no data were serialized nothing needs to be done here.'''
         return None
 
+    def dumps(self):
+        '''When saving the document this object gets stored using Python's json module.\
+            Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
+            to return a tuple of all serializable objects or None.'''
+        return None
+
+    def loads(self, state):
+        '''When restoring the serialized object from document we have the chance to set some internals here.\
+            Since no data were serialized nothing needs to be done here.'''
+        return None
+
     def setEdit(self, vobj, mode):
          #nacelleTaskPanel.ui
         taskd = NacelleTaskPanel(vobj)

--- a/airPlanePanel.py
+++ b/airPlanePanel.py
@@ -183,7 +183,18 @@ class ViewProviderPanel:
             to return a tuple of all serializable objects or None.'''
         return None
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
+        '''When restoring the serialized object from document we have the chance to set some internals here.\
+            Since no data were serialized nothing needs to be done here.'''
+        return None
+
+    def dumps(self):
+        '''When saving the document this object gets stored using Python's json module.\
+            Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
+            to return a tuple of all serializable objects or None.'''
+        return None
+
+    def loads(self, state):
         '''When restoring the serialized object from document we have the chance to set some internals here.\
             Since no data were serialized nothing needs to be done here.'''
         return None

--- a/airPlanePlane.py
+++ b/airPlanePlane.py
@@ -146,7 +146,18 @@ class ViewProviderPlane:
             to return a tuple of all serializable objects or None.'''
         return None
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
+        '''When restoring the serialized object from document we have the chance to set some internals here.\
+            Since no data were serialized nothing needs to be done here.'''
+        return None
+
+    def dumps(self):
+        '''When saving the document this object gets stored using Python's json module.\
+            Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
+            to return a tuple of all serializable objects or None.'''
+        return None
+
+    def loads(self, state):
         '''When restoring the serialized object from document we have the chance to set some internals here.\
             Since no data were serialized nothing needs to be done here.'''
         return None

--- a/airPlaneRib.py
+++ b/airPlaneRib.py
@@ -329,7 +329,18 @@ class ViewProviderWingRib:
             to return a tuple of all serializable objects or None.'''
         return None
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
+        '''When restoring the serialized object from document we have the chance to set some internals here.\
+            Since no data were serialized nothing needs to be done here.'''
+        return None
+
+    def dumps(self):
+        '''When saving the document this object gets stored using Python's json module.\
+            Since we have some un-serializable parts here -- the Coin stuff -- we must define this method\
+            to return a tuple of all serializable objects or None.'''
+        return None
+
+    def loads(self, state):
         '''When restoring the serialized object from document we have the chance to set some internals here.\
             Since no data were serialized nothing needs to be done here.'''
         return None

--- a/airPlaneSWPanel.py
+++ b/airPlaneSWPanel.py
@@ -133,7 +133,13 @@ class ViewProviderPanel:
     def __getstate__(self):
         return None
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
+        return None
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
         return None
 
 class CommandWPanel:

--- a/airPlaneWPanel.py
+++ b/airPlaneWPanel.py
@@ -642,7 +642,13 @@ class ViewProviderPanel:
     def __getstate__(self):
         return None
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
+        return None
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
         return None
 
 class CommandWPanel:

--- a/airPlaneWing.py
+++ b/airPlaneWing.py
@@ -217,7 +217,13 @@ class ViewProviderWing:
     def __getstate__(self):
         return None
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
+        return None
+
+    def dumps(self):
+        return None
+
+    def loads(self, state):
         return None
 
     def setEdit(self,vobj,mode):

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <package format="1">
   <name>AirplaneDesign</name>
   <description>A FreeCAD workbench dedicated to Airplane Design.</description>
-  <version>0.4</version>
+  <version>0.4.1</version>
   <maintainer email="@fredsfactory.fr">FredsFactory</maintainer>
   <license file="LICENSE">LGPL-2.1</license>
   <url type="repository" branch="master">https://github.com/FredsFactory/FreeCAD_AirPlaneDesign</url>


### PR DESCRIPTION
…and above

In order to fix errors using Python 3.11.x and above while preserving ability for Python 3.10.x and below to still work correctly, example error from another workbench:

```
  File "/usr/lib/python3.11/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
<class 'TypeError'>: Object of type FeaturePython is not JSON serializable
17:04:02  PropertyPythonObject::toString(): failed for <class 'SheetMetalCmd.SMViewProviderFlat'>
17:04:02  pyException: Traceback (most recent call last):
  File "/usr/lib/python3.11/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
```

Root Cause is https://github.com/FreeCAD/FreeCAD/commit/fbe2fef

Note: I am trying to contact the owner of CurvedShapes Wb as it's a dependency and therefore must be changed as well otherwise it's likely to still fail on saving the file.