### PR TITLE
Fix UI file paths causing RuntimeError

### DIFF
--- a/airPlaneDesignProfilUI.py
+++ b/airPlaneDesignProfilUI.py
@@ -46,12 +46,12 @@ class zoomableGraphic(QtGui.QGraphicsView):
 
 class SelectObjectUI():
     def __init__(self):
-        path_to_ui = FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/resources/selectRibProfil.ui'
+        path_to_ui = os.path.join(os.path.dirname(__file__), 'resources', 'selectRibProfil.ui')
         loader=QtUiTools.QUiLoader()
         loader.registerCustomWidget(zoomableGraphic)
         self.form=loader.load(path_to_ui)
         #self.form.setWindowFlag(QtCore.Qt.WindowMaximizeButtonHint) # compatibility with Freecad V0.18
-        profil_dir=FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/wingribprofil'
+        profil_dir = os.path.join(os.path.dirname(__file__), 'wingribprofil')
         self.model = QtGui.QFileSystemModel()
         self.model.setRootPath(profil_dir)
         tree =  self.form.listProfil

--- a/airPlanePanel.py
+++ b/airPlanePanel.py
@@ -29,6 +29,7 @@ __url__ = "https://fredsfactory.fr"
 
 import FreeCAD
 import FreeCADGui
+import os
 
 from airPlaneRib import WingRib, ViewProviderWingRib
 from airPlaneWingUI import WingEditorPanel
@@ -40,7 +41,7 @@ from airPlaneWingUI import WingEditorPanel
 if open.__module__ in ['__builtin__','io', '_io']:
     pythonopen = open
 
-_wingRibProfilDir=FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/wingribprofil'
+_wingRibProfilDir = os.path.join(os.path.dirname(__file__), 'wingribprofil')
 
 class WPanel:
     def __init__(self, obj,_NberOfPanel,_panelInput):

--- a/airPlanePlane.py
+++ b/airPlanePlane.py
@@ -82,7 +82,7 @@ class PlaneTaskPanel:
     def __init__(self,vobj):
         print("init RibTaskPanel")
         self.obj = vobj
-        path_to_ui = FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/resources/airPlaneDesignEdit.ui'
+        path_to_ui = os.path.join(os.path.dirname(__file__), 'resources', 'airPlaneDesignEdit.ui')
         self.form = FreeCADGui.PySideUic.loadUi(path_to_ui)
         self.update(vobj)
 

--- a/airPlaneRib.py
+++ b/airPlaneRib.py
@@ -116,7 +116,7 @@ class RibTaskPanel:
     '''A TaskPanel for the Rib'''
     def __init__(self,vobj):
         self.obj = vobj
-        path_to_ui = FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/resources/ribTaskPanel.ui'
+        path_to_ui = os.path.join(os.path.dirname(__file__), 'resources', 'ribTaskPanel.ui')
         self.form = FreeCADGui.PySideUic.loadUi(path_to_ui)
         self.update(vobj)
         self.form.xfoilSimulation.clicked.connect(self.xfoilSimulation)

--- a/airPlaneSWPanel.py
+++ b/airPlaneSWPanel.py
@@ -40,7 +40,7 @@ def translate(context, text, disambig=None):
 if open.__module__ in ['__builtin__','io', '_io']:
     pythonopen = open
 
-_wingRibProfilDir=FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/wingribprofil'
+_wingRibProfilDir = os.path.join(os.path.dirname(__file__), 'wingribprofil')
 
 class WingSPanel:
     def __init__(self, obj, _rootRib ,_tipRib ,_rootChord=200,_tipChord=100,_panelLength=100,_tipTwist=0,_dihedral=0):

--- a/airPlaneWPanel.py
+++ b/airPlaneWPanel.py
@@ -25,7 +25,7 @@ __url__ = "https://fredsfactory.fr"
 import FreeCADGui
 import FreeCAD
 from FreeCAD import Vector
-import Part, Draft
+import Part, Draft, os
 from PySide import QtGui, QtCore
 import WorkingPlane
 import CompoundTools.Explode
@@ -219,7 +219,7 @@ def distribute(x, distribution, reverse = False):
 if open.__module__ in ['__builtin__','io', '_io']:
     pythonopen = open
 
-_wingRibProfilDir=FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/wingribprofil'
+_wingRibProfilDir = os.path.join(os.path.dirname(__file__), 'wingribprofil')
 
 class WingPanel:
     def __init__(self,

--- a/airPlaneWing.py
+++ b/airPlaneWing.py
@@ -49,7 +49,7 @@ def translate(context, text, disambig=None):
 if open.__module__ in ['__builtin__','io', '_io']:
     pythonopen = open
 
-_wingRibProfilDir=FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/wingribprofil'
+_wingRibProfilDir = os.path.join(os.path.dirname(__file__), 'wingribprofil')
 
 class Wing:
     def __init__(self, obj, _wPanels):
@@ -134,7 +134,7 @@ class WingTaskPanel:
     '''A TaskPanel for the Rib'''
     def __init__(self,vobj):
         self.obj = vobj
-        path_to_ui = FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/resources/airPlaneWpanelTask.ui'
+        path_to_ui = os.path.join(os.path.dirname(__file__), 'resources', 'airPlaneWpanelTask.ui')
         self.form = FreeCADGui.PySideUic.loadUi(path_to_ui)
         self.update(vobj)
 

--- a/airPlaneWingUI.py
+++ b/airPlaneWingUI.py
@@ -12,6 +12,7 @@
 ################################################
 import FreeCAD
 import FreeCADGui
+import os
 from PySide import QtCore
 from PySide import QtGui
 
@@ -24,7 +25,7 @@ def translate(context, text, disambig=None):
 
 class WingEditorPanel():
     def __init__(self):
-        path_to_ui = FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/resources/airPlaneDesignWingdialog.ui'
+        path_to_ui = os.path.join(os.path.dirname(__file__), 'resources', 'airPlaneDesignWingdialog.ui')
         self.form = FreeCADGui.PySideUic.loadUi(path_to_ui)
         self.form.airPlaneName.setText("nom")
 
@@ -40,7 +41,7 @@ class WingEditorPanel():
         return int(QtGui.QDialogButtonBox.Ok)
 
     def loadPanelTable(self):
-        _wingRibProfilDir=FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/wingribprofil'
+        _wingRibProfilDir = os.path.join(os.path.dirname(__file__), 'wingribprofil')
 
         ##########################
         # Numéro du panneau, profil, fichier profil, , corde emplature, corde saumon, longueur paneau, X emplature, X saumon, Y emplature, Y saumon, Z emplature, Z saumon, X Rotation, Y Rotation, Z Rotation

--- a/airPlaneWingWizard.py
+++ b/airPlaneWingWizard.py
@@ -27,6 +27,7 @@ __url__ = "https://fredsfactory.fr"
 
 import FreeCAD
 import FreeCADGui
+import os
 from airPlaneSWPanel import WingSPanel,ViewProviderPanel
 from airPlaneRib import WingRib, ViewProviderWingRib
 from airPlaneWingUI import WingEditorPanel
@@ -38,7 +39,7 @@ from airPlaneWingUI import WingEditorPanel
 if open.__module__ in ['__builtin__','io', '_io']:
     pythonopen = open
 
-_wingRibProfilDir=FreeCAD.getUserAppDataDir()+ 'Mod/AirPlaneDesign/wingribprofil'
+_wingRibProfilDir = os.path.join(os.path.dirname(__file__), 'wingribprofil')
 
 
 


### PR DESCRIPTION
## Fix UI file paths causing RuntimeError

Fixes #32

FreeCAD version info:
```
OS: Ubuntu 24.04.3 LTS (ubuntu:GNOME/ubuntu/xcb)
Architecture: x86_64
Version: 1.0.2.39319 (Git) Conda AppImage
Build type: Release
Branch: (HEAD detached at 1.0.2)
Hash: 256fc7eff3379911ab5daf88e10182c509aa8052
Python 3.11.13, Qt 5.15.15, Coin 4.0.3, Vtk 9.3.0, OCC 7.8.1
Locale: English/United States (en_US)
Stylesheet/Theme/QtStyle: FreeCAD Light.qss/FreeCAD Light/Fusion
Installed mods: 
  * FreeCAD_AirPlaneDesign 0.4.1
  * CurvedShapesWorkbench 1.0.14
```

### Problem
The workbench was using `FreeCAD.getUserAppDataDir() + 'Mod/AirPlaneDesign/...'` to construct paths to UI files and resources. This approach fails because it assumes a specific installation location that doesn't match where the addon is actually installed.

### Solution
- Replaced all instances of `FreeCAD.getUserAppDataDir() + 'Mod/AirPlaneDesign/...'` with `os.path.join(os.path.dirname(__file__), ...)`
- This approach uses paths relative to the module's actual location, making it work regardless of installation method

### Files Changed
- `airPlaneWing.py` - Fixed wing UI path
- `airPlanePlane.py` - Fixed plane UI path
- `airPlaneRib.py` - Fixed rib UI path
- `airPlaneWingUI.py` - Fixed wing dialog UI path and wingribprofil directory
- `airPlaneDesignProfilUI.py` - Fixed profile selector UI path and wingribprofil directory
- `airPlanePanel.py` - Fixed wingribprofil directory path, added os import
- `airPlaneSWPanel.py` - Fixed wingribprofil directory path
- `airPlaneWingWizard.py` - Fixed wingribprofil directory path, added os import
- `airPlaneWPanel.py` - Fixed wingribprofil directory path, added os import

### Testing
Verified that:
- Wing creation dialog opens without errors
- Rib creation dialog opens without errors
- Profile selector loads correctly
